### PR TITLE
Conditionally add records to a route53 zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,13 @@ module "static_site_hosting" {
 | Name | Type |
 |------|------|
 | [aws_acm_certificate.cloudfront_static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.cloudfront_static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
 | [aws_cloudfront_cache_policy.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_distribution.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_cloudfront_origin_access_control.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
 | [aws_cloudfront_origin_request_policy.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
+| [aws_route53_record.cloudfront_static_site_tls_certificate_dns_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.cloudfront_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
@@ -104,6 +107,7 @@ module "static_site_hosting" {
 | [aws_s3_bucket_website_configuration.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
+| [aws_route53_zone.static_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
@@ -122,6 +126,7 @@ module "static_site_hosting" {
 | <a name="input_enable_cloudfront_static_site_logs"></a> [enable\_cloudfront\_static\_site\_logs](#input\_enable\_cloudfront\_static\_site\_logs) | Enable CloudFront Staci Site logging to the logs bucket | `bool` | `true` | no |
 | <a name="input_enable_s3_access_logs"></a> [enable\_s3\_access\_logs](#input\_enable\_s3\_access\_logs) | Enable S3 access logs | `bool` | `true` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project Name | `string` | n/a | yes |
+| <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | Route53 zone id. If provided, the certificate validation records and site records will be created in that zone | `string` | `""` | no |
 | <a name="input_s3_logs_force_destroy"></a> [s3\_logs\_force\_destroy](#input\_s3\_logs\_force\_destroy) | Force destroy Logs S3 bucket | `bool` | `false` | no |
 | <a name="input_s3_static_site_force_destroy"></a> [s3\_static\_site\_force\_destroy](#input\_s3\_static\_site\_force\_destroy) | Force destroy Static Site S3 bucket | `bool` | `false` | no |
 | <a name="input_site_host_name"></a> [site\_host\_name](#input\_site\_host\_name) | Site Host Name. This will be used for Certificate generation and CloudFront aliases | `string` | `""` | no |

--- a/certificates.tf
+++ b/certificates.tf
@@ -11,3 +11,12 @@ resource "aws_acm_certificate" "cloudfront_static_site" {
     create_before_destroy = true
   }
 }
+
+resource "aws_acm_certificate_validation" "cloudfront_static_site" {
+  provider = aws.useast1
+
+  count = local.cloudfront_static_site_tls_certificate_arn == "" && local.route53_zone_id != "" ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.cloudfront_static_site[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.cloudfront_static_site_tls_certificate_dns_validation : record.fqdn]
+}

--- a/cloudfront-static-site.tf
+++ b/cloudfront-static-site.tf
@@ -144,4 +144,8 @@ resource "aws_cloudfront_distribution" "static_site" {
       prefix          = "cloudfront/static_site"
     }
   }
+
+  depends_on = [
+    aws_acm_certificate_validation.cloudfront_static_site
+  ]
 }

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_canonical_user_id" "current" {}
+
+data "aws_route53_zone" "static_site" {
+  count = local.route53_zone_id != "" ? 1 : 0
+
+  zone_id = local.route53_zone_id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,8 @@
 locals {
-  project_name   = var.project_name
-  account_id     = data.aws_caller_identity.current.account_id
-  site_host_name = var.site_host_name
+  project_name    = var.project_name
+  account_id      = data.aws_caller_identity.current.account_id
+  site_host_name  = var.site_host_name
+  route53_zone_id = var.route53_zone_id
 
   s3_bucket_policy_statement_enforce_tls_path    = "${path.module}/policies/s3-bucket-policy-statements/enforce-tls.json.tpl"
   s3_bucket_policy_statement_log_delivery_access = "${path.module}/policies/s3-bucket-policy-statements/log-delivery-access.json.tpl"

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,29 @@
+resource "aws_route53_record" "cloudfront_static_site_tls_certificate_dns_validation" {
+  for_each = local.cloudfront_static_site_tls_certificate_arn == "" && local.route53_zone_id != "" ? {
+    for dvo in aws_acm_certificate.cloudfront_static_site[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id = data.aws_route53_zone.static_site[0].zone_id
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+  ttl     = "86400"
+}
+
+resource "aws_route53_record" "static_site" {
+  count = local.route53_zone_id != "" ? 1 : 0
+
+  zone_id = data.aws_route53_zone.static_site[0].zone_id
+  name    = local.site_host_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.static_site[0].domain_name
+    zone_id                = aws_cloudfront_distribution.static_site[0].hosted_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "site_host_name" {
   default     = ""
 }
 
+variable "route53_zone_id" {
+  description = "Route53 zone id. If provided, the certificate validation records and site records will be created in that zone"
+  type        = string
+  default     = ""
+}
+
 variable "static_site_s3_acl" {
   description = "Static Site S3 ACL"
   type        = string


### PR DESCRIPTION
* Providing a Route53 zone id will create the certificate validation records, and site records in that zone