### PR TITLE
Fix cloudfront logs bucket ACL

### DIFF
--- a/s3-logs.tf
+++ b/s3-logs.tf
@@ -40,7 +40,7 @@ resource "aws_s3_bucket_acl" "cloudfront_logs" {
         id   = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
         type = "CanonicalUser"
       }
-      permission = "WRITE"
+      permission = "FULL_CONTROL"
     }
     owner {
       id = data.aws_canonical_user_id.current.id


### PR DESCRIPTION
* The 'WRITE' permission is overwritten with the 'FULL_CONTROL' permission